### PR TITLE
Clean up of Cellular Automata example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,19 @@ a GUI that goes with it.  This example demonstrates:
 * TraitsUI handlers.
 * simple TraitsUI Action usage.
 
+Cellular Automation Library
+---------------------------
+
+A Traits library that provides tools to explore and run various cellular
+automaton simulations (such as  Conway's "game of life").  This example
+demonstrates
+
+* a moderately complex Traits model for "business logic".
+* using abstract base classes with Traits to specify interfaces.
+* using composition rather than inheritance to produce behaviours.
+* using Traits notification system to observe model state independent
+  without the model needing to specifically support observation.
+
 License
 -------
 

--- a/cellular-automata/cellular_automata/abstract_initializer.py
+++ b/cellular-automata/cellular_automata/abstract_initializer.py
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2017, Enthought, Inc.
 # All rights reserved.
 #

--- a/cellular-automata/cellular_automata/abstract_rule.py
+++ b/cellular-automata/cellular_automata/abstract_rule.py
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2017, Enthought, Inc.
 # All rights reserved.
 #

--- a/cellular-automata/cellular_automata/automata_recorder.py
+++ b/cellular-automata/cellular_automata/automata_recorder.py
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2017, Enthought, Inc.
 # All rights reserved.
 #

--- a/cellular-automata/cellular_automata/automata_traits.py
+++ b/cellular-automata/cellular_automata/automata_traits.py
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2017, Enthought, Inc.
 # All rights reserved.
 #

--- a/cellular-automata/cellular_automata/cellular_automaton.py
+++ b/cellular-automata/cellular_automata/cellular_automaton.py
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2017, Enthought, Inc.
 # All rights reserved.
 #

--- a/cellular-automata/cellular_automata/initializers/pattern_overlay.py
+++ b/cellular-automata/cellular_automata/initializers/pattern_overlay.py
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2017, Enthought, Inc.
 # All rights reserved.
 #

--- a/cellular-automata/cellular_automata/initializers/random_choice.py
+++ b/cellular-automata/cellular_automata/initializers/random_choice.py
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2017, Enthought, Inc.
 # All rights reserved.
 #

--- a/cellular-automata/cellular_automata/initializers/random_overlay.py
+++ b/cellular-automata/cellular_automata/initializers/random_overlay.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2017, Enthought, Inc.
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 import numpy as np
 
 from cellular_automata.abstract_initializer import AbstractInitializer

--- a/cellular-automata/cellular_automata/io/image.py
+++ b/cellular-automata/cellular_automata/io/image.py
@@ -88,7 +88,7 @@ def _save_animated_gif(arrays, filename, palette=None, duration=50):
         image = Image.fromarray(array, mode)
         if mode == 'P':
             palette = np.array(palette, dtype='uint8').ravel()
-            image.putpalette(palette)
+            image.putpalette(palette.tobytes())
         images.append(image)
 
     images[0].save(

--- a/cellular-automata/cellular_automata/rules/forest.py
+++ b/cellular-automata/cellular_automata/rules/forest.py
@@ -53,7 +53,7 @@ class BurnRule(StructureRule):
         return FIRE_STRUCTURE
 
 
-class SlowBurnRule(StructureRule):
+class SlowBurnRule(BurnRule):
     """ A rule that sets on fire burnable cells that neighbour a burning cell.
 
     Neighbouring cells are determined by a connectivity structure.  Cells which
@@ -69,7 +69,7 @@ class SlowBurnRule(StructureRule):
     # ------------------------------------------------------------------------
 
     def step(self, states):
-        states = super(BurnRule, self).step(states)
+        states = super(SlowBurnRule, self).step(states)
 
         burning = (states == self.burning_state)
         burnable_mask = (states == self.burnable_state)
@@ -82,6 +82,7 @@ class SlowBurnRule(StructureRule):
         states[burning] = self.burnt_state
 
         return states
+
 
 class BurnGrovesRule(BurnRule):
     """ A rule that burns down entire burnable connected components.

--- a/cellular-automata/cellular_automata/rules/tests/test_base_rules.py
+++ b/cellular-automata/cellular_automata/rules/tests/test_base_rules.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2017, Enthought, Inc.
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from unittest import TestCase
 
 import numpy as np

--- a/cellular-automata/cellular_automata/rules/tests/test_elementary_1d_rule.py
+++ b/cellular-automata/cellular_automata/rules/tests/test_elementary_1d_rule.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2017, Enthought, Inc.
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from unittest import TestCase
 
 import numpy as np

--- a/cellular-automata/cellular_automata/tests/test_automata_recorder.py
+++ b/cellular-automata/cellular_automata/tests/test_automata_recorder.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2017, Enthought, Inc.
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 from unittest import TestCase
 
 import numpy as np

--- a/cellular-automata/examples/elementary_automata.py
+++ b/cellular-automata/examples/elementary_automata.py
@@ -11,6 +11,9 @@
 # Thanks for using Enthought open source!
 
 """
+Elementary 1D Cellular Automata
+===============================
+
 This script demonstrates the basic use of the cellular_automata library to
 display `Elementary 1D Cellular Automata
 <https://https://en.wikipedia.org/wiki/Elementary_cellular_automaton>`_ at the
@@ -40,6 +43,7 @@ def main(rule, size, pattern, boundary, ticks):
     # setup simulation
     rule = Elementary1DRule(rule_number=rule, boundary=boundary)
     pattern_overlay = PatternOverlay(pattern=pattern)
+
     world = CellularAutomaton(
         shape=(size,),
         initializers=[pattern_overlay],
@@ -54,6 +58,7 @@ def main(rule, size, pattern, boundary, ticks):
     for i in range(ticks):
         world.step()
         print(automaton_to_text(world))
+
 
 if __name__ == '__main__':
     main()

--- a/cellular-automata/examples/forest_fire.py
+++ b/cellular-automata/examples/forest_fire.py
@@ -1,3 +1,45 @@
+# Copyright (c) 2017, Enthought, Inc.
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Forest Fire Simulation
+======================
+
+This example runs cellular automata simulation and saves the results as a
+GIF image.
+
+In this example, we use a modified version of a forest fire
+simulation with the following states:
+
+- Empty cell: 0
+- Healthy tree: 1
+- Burning tree: 2
+
+Every tick:
+
+- an empty cell can grow a tree
+- lightning randomly starts fires in trees
+- fire spreads to neighbouring trees and trees which were previously
+  on fire die
+
+See also
+--------
+
+This model was originally introduced in:
+
+    Drossel, B. and Schwabl, F. (1992),
+    "Self-organized critical forest-fire model."
+    Phys. Rev. Lett. 69, 1629–1632.
+
+"""
+
 import numpy as np
 
 from cellular_automata.automata_recorder import AutomataRecorder
@@ -7,17 +49,37 @@ from cellular_automata.rules.forest import SlowBurnRule
 from cellular_automata.io.image import save_image_sequence
 
 
+# State values
+EMPTY = 0
+TREE = 1
+FIRE = 2
+
+# State colors
+GREEN = [0, 255, 0]
+RED = [255, 0, 0]
+WHITE = [255, 255, 255]
+
+
 def simulation(size, steps):
+    """ Perform a simulation of a forest fire, outputting a GIF.
+
+    Parameters
+    ----------
+    size : size tuple
+        The number of cells in each direction for the simulation.
+    steps : int
+        The number of ticks to run the simulation for.
+    """
     np.random.seed(None)
 
     grow = ChangeStateRule(
-        from_state=0,
-        to_state=1,
+        from_state=EMPTY,
+        to_state=TREE,
         p_change=0.0025
     )
     lightning = ChangeStateRule(
-        from_state=1,
-        to_state=2,
+        from_state=TREE,
+        to_state=FIRE,
         p_change=1e-5,
     )
     burn = SlowBurnRule()
@@ -33,15 +95,14 @@ def simulation(size, steps):
         forest.step()
 
     palette = np.zeros((256, 3), dtype='uint8')
-    palette[1] = [0, 255, 0]
-    palette[2] = [255, 0, 0]
-    palette[3] = [255, 255, 255]
+    palette[1] = GREEN
+    palette[2] = RED
 
     save_image_sequence(recorder, 'test.gif', palette, 100)
+
 
 if __name__ == '__main__':
     SHAPE = (256, 256)
     N_STEPS = 4096
-    N_SIMULATIONS = 16
 
     simulation(SHAPE, N_STEPS)

--- a/cellular-automata/examples/forest_fire_parameter_exploration.py
+++ b/cellular-automata/examples/forest_fire_parameter_exploration.py
@@ -3,8 +3,7 @@ import numpy as np
 from cellular_automata.automata_recorder import AutomataRecorder, count_states
 from cellular_automata.cellular_automaton import CellularAutomaton
 from cellular_automata.rules.change_state_rule import ChangeStateRule
-from cellular_automata.rules.forest import SlowBurnRule, BurnGrovesRule, MoldRule
-#from cellular_automata.io.image import save_image_sequence
+from cellular_automata.rules.forest import BurnGrovesRule, MoldRule
 
 
 def simulation(p_mold, size, steps, transform=None):
@@ -15,12 +14,6 @@ def simulation(p_mold, size, steps, transform=None):
         to_state=1,
         p_change=0.0025
     )
-    # lightning = ChangeStateRule(
-    #     from_state=1,
-    #     to_state=2,
-    #     p_change=1e-5,
-    # )
-    # burn = SlowBurnRule()
     burn_groves = BurnGrovesRule()
     mold = MoldRule(dead_state=3, p_mold=p_mold)
     mold_die = ChangeStateRule(
@@ -46,14 +39,6 @@ def simulation(p_mold, size, steps, transform=None):
 
     return recorder.as_array()[:, 1:4].T
 
-
-#
-# palette = np.zeros((256, 3), dtype='uint8')
-# palette[1] = [0, 255, 0]
-# palette[2] = [255, 0, 0]
-# palette[3] = [255, 255, 255]
-#
-# save_image_sequence(recorder, 'test.gif', palette, 100)
 
 if __name__ == '__main__':
     from joblib import Parallel, delayed

--- a/cellular-automata/examples/forest_fire_parameter_exploration.py
+++ b/cellular-automata/examples/forest_fire_parameter_exploration.py
@@ -1,3 +1,43 @@
+# Copyright (c) 2017, Enthought, Inc.
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Forest Fire Parameter Exploration
+=================================
+
+This example shows parallel execution of multiple forest fire
+simulations with parameters swept over a range of values to
+collect and display statistics about the model.
+
+In this example, we use a modified version of a forest fire
+simulation with the following states:
+
+- Empty cell: 0
+- Healthy tree: 1
+- Burning tree: 2
+- Moldy tree: 3
+
+Every tick:
+
+- an empty cell can grow a tree
+- fires are randomly started and burn down all connected trees
+- crowded trees have a chance of contracting and dying from mold
+  infection
+
+The script runs the simulation with different values for the
+likelihood of mold infection.  As the probability grows, a qualitative
+decrease can be seen in the size and effect of fires, as the deaths
+due to mold have the effect of breaking up large groups of trees into
+less-connected groves, making it harder for fire to spread.
+"""
+
 import numpy as np
 
 from cellular_automata.automata_recorder import AutomataRecorder, count_states
@@ -6,24 +46,57 @@ from cellular_automata.rules.change_state_rule import ChangeStateRule
 from cellular_automata.rules.forest import BurnGrovesRule, MoldRule
 
 
-def simulation(p_mold, size, steps, transform=None):
+# State values
+EMPTY = 0
+TREE = 1
+FIRE = 2
+MOLD = 3
+
+
+def simulation(p_mold, size, steps):
+    """ Perform a simulation of a moldy forest, returning statistics.
+
+    Parameters
+    ----------
+    p_mold : probability
+        The probability that a crowded tree dies of mold.
+    size : size tuple
+        The number of cells in each direction for the simulation.
+    steps : int
+        The number of ticks to run the simulation for.
+
+    Returns
+    -------
+    counts : array
+        Array with shape (4, steps) of counts of each state at
+        each tick.
+    """
     np.random.seed(None)
 
+    # trees grow
     grow = ChangeStateRule(
-        from_state=0,
-        to_state=1,
+        from_state=EMPTY,
+        to_state=TREE,
         p_change=0.0025
     )
+
+    # fires are started, and all connected trees burn
     burn_groves = BurnGrovesRule()
-    mold = MoldRule(dead_state=3, p_mold=p_mold)
+
+    # crowded trees have a chance to be infected with mold
+    mold = MoldRule(dead_state=MOLD, p_mold=p_mold)
+
+    # trees which are infected with mold die
     mold_die = ChangeStateRule(
-        from_state=3,
-        to_state=0,
+        from_state=MOLD,
+        to_state=EMPTY,
         p_change=1.0
     )
+
+    # fires are extinguished
     fire_out = ChangeStateRule(
-        from_state=2,
-        to_state=0,
+        from_state=FIRE,
+        to_state=EMPTY,
         p_change=1.0
     )
 
@@ -31,13 +104,15 @@ def simulation(p_mold, size, steps, transform=None):
         shape=size,
         rules=[mold_die, fire_out, grow, burn_groves, mold],
     )
-    recorder = AutomataRecorder(automaton=forest, transform=transform)
+
+    # record the number of each state
+    recorder = AutomataRecorder(automaton=forest, transform=count_states)
 
     forest.start()
     for i in range(steps):
         forest.step()
 
-    return recorder.as_array()[:, 1:4].T
+    return recorder.as_array()
 
 
 if __name__ == '__main__':
@@ -54,9 +129,15 @@ if __name__ == '__main__':
     )
 
     for i, result in enumerate(results):
+        # plot count of each non-empty state over time
         plt.subplot(N_SIMULATIONS, 2, 2*i+1)
-        for j, color in enumerate('grc'):
-            plt.plot(result[j], c=color)
+        for state, color in [(TREE, 'g'), (FIRE, 'r'), (MOLD, 'c')]:
+            plt.plot(result[state, :], c=color)
+
+        # plot histogram
         plt.subplot(N_SIMULATIONS, 2, 2*i+2)
-        plt.hist(np.log(result[1, result[1] != 0]), bins=np.linspace(0, 10, 21))
+        plt.hist(
+            np.log(result[result[1] != 0, 1]),
+            bins=np.linspace(0, 10, 21)
+        )
     plt.show()

--- a/docs/source/cellular-automata.rst
+++ b/docs/source/cellular-automata.rst
@@ -8,7 +8,7 @@ Cellular Automata Library
 This example shows how to build a library using Traits for the object models.
 The key design patterns are:
 
-* use of :py:class:`ABCStrictHasTraits` to specify interfaces and basic
+* use of :py:class:`ABCHasStrictTraits` to specify interfaces and basic
   implementation and subclasses to provide particular implementations.  In
   particular look at :py:class:`.AbstractRule` and the various classes defined
   in :py:mod:`cellular_automata.rules` to see this pattern in action.


### PR DESCRIPTION
- Python 3 support (fixes #7)
- better docstrings
- copyright headers everywhere